### PR TITLE
Use Async Ossfs

### DIFF
--- a/dvc_oss/__init__.py
+++ b/dvc_oss/__init__.py
@@ -29,7 +29,7 @@ class OSSFileSystem(ObjectFileSystem):
     @wrap_prop(threading.Lock())
     @cached_property
     def fs(self):
-        from ossfs import OSSFileSystem as _OSSFileSystem
+        from ossfs import AioOSSFileSystem as _OSSFileSystem
 
         return _OSSFileSystem(**self.fs_args)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 include_package_data = True
 install_requires =
     dvc
-    ossfs
+    ossfs>=2023.5.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
Use async ossfs to improve the performance.

1. Use Async version of the ossfs to replace the sync one.
2. bump ossfs into the latest version.

I'm sorry I do not have permission to push directly to this repository.  